### PR TITLE
Added auto-scroll using ALT+Wheel & Fixed zoom bug…

### DIFF
--- a/renderers/js/mouse-controls.js
+++ b/renderers/js/mouse-controls.js
@@ -1,3 +1,13 @@
+// Timeout to prevent repeat scroll events
+let isScrolling = false;
+let scrollTimeout = null;
+// Auto scroll handler
+const defaultAutoScrollSpeed = 2;
+let isAutoScrolling = false;
+let scrollPosition = 0;
+let autoScrollSpeed = 0; // px per animation key
+let autoScrollDirection = 1; // 1 = down, -1 = up
+
 // Listen for the wheel event to adjust the CSS property
 imageGrid.addEventListener('wheel', event => {
   processWheel(event);
@@ -7,16 +17,26 @@ gridWrapper.addEventListener('wheel', event => {
 });
 
 function processWheel(event) {
+  if( isScrolling ){
+    return;
+  }
+  isScrolling = true;
+  clearTimeout(scrollTimeout);
+  scrollTimeout = setTimeout( () => {
+    isScrolling = false;
+  }, 50 );
   if (event.ctrlKey) {
     event.preventDefault();
   
     // Determine the direction of the scroll
-    const zoomAmount = event.deltaY > 0 ? 0.75 : 1.25;
+    const zoomAmount = event.deltaY > 0 ? 0.8 : 1.2;
     currentZoom *= zoomAmount;
     currentZoom = Math.max(currentZoom, 0.1);
-    updateGridAndSpacing();  
+    updateGridAndSpacing();
     // Trigger Masonry Layout's layout after changing the CSS property
-    grid.layout();    
+    grid.layout();
+    // Stop any active auto-scroll
+    stopAutoScroll();
   }
   else if (event.shiftKey)
   {
@@ -27,5 +47,51 @@ function processWheel(event) {
     updateGridAndSpacing();
     // Trigger Masonry Layout's layout after changing the CSS property
     grid.layout();
+    // Stop any active auto-scroll
+    stopAutoScroll();
   }
+  else if (event.altKey)
+  {
+    event.preventDefault();
+    // Determine the direction of the scroll
+    const scrollDirection = event.deltaY > 0 ? 1 : -1;
+    if( isAutoScrolling ){
+      // Already running
+      const speedAdjust = autoScrollDirection != scrollDirection ? 0.8 : 1.2;
+      autoScrollSpeed *= speedAdjust;
+      autoScrollSpeed = Math.max(autoScrollSpeed, 1);
+    }
+    else
+    {
+      // Start a new auto-scroll event
+      autoScrollSpeed = defaultAutoScrollSpeed;
+      autoScrollDirection = scrollDirection;
+      scrollPosition = window.scrollY;
+      isAutoScrolling = true;
+      requestAnimationFrame(autoScrollKeyframe);
+    }
+  }
+  else
+  { // Just a plain-old scroll
+    stopAutoScroll();
+  }
+}
+
+function autoScrollKeyframe() {
+  if( !isAutoScrolling ){
+      return;
+  }
+
+  const scrollAmount = autoScrollSpeed * autoScrollDirection;
+  scrollPosition += scrollAmount;
+  
+  window.scrollTo({ top: scrollPosition, behavior: 'instant' });
+
+  requestAnimationFrame(autoScrollKeyframe);
+}
+
+function stopAutoScroll(){
+    if( isAutoScrolling ){
+        isAutoScrolling = false;
+    }
 }


### PR DESCRIPTION
This pull request adds an auto-scroll feature. This allows the page to scroll up or down automatically, continuously. Activate this using ALT + Mouse-Wheel. The speed can be adjusted by repeating this action. Stop the auto-scroll by scrolling normally.

Also adds a fix for any mouse with an accelerated scroll-wheel (by adding a debounce on scroll actions). This bug meant that accurately zooming in/out was impossible as the scroll event would be triggered tens of times on each scroll action (ie. tiny images after a single CTRL + Scroll-down and full-page images after a single CTRL + Scroll-up). Adding a simple debounce fixes this.

Issues: auto-scroll currently does not stop when clicking on an image. This would be a simple fix, but I wanted to keep changes contained to one file for easier review/adjustment.